### PR TITLE
Use --depth=1 flag when cloning repositories to save some time

### DIFF
--- a/jjb/dynamic/SVT_prometheus_scaling.yml
+++ b/jjb/dynamic/SVT_prometheus_scaling.yml
@@ -6,7 +6,7 @@
         set -x
 
         if [[ ! -d "${WORKSPACE}/perf-dept" ]]; then
-        git clone https://${GITHUB_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${GITHUB_TOKEN}@github.com/redhat-performance/perf-dept.git
         fi
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         chmod 600 ${PRIVATE_KEY}
@@ -33,7 +33,7 @@
         if [[ -d "/root/scale-cd-jobs" ]]; then
         rm -rf /root/scale-cd-jobs
         fi
-        git clone https://github.com/chaitanyaenr/scale-cd-jobs.git /root/scale-cd-jobs
+        git clone --depth=1 https://github.com/chaitanyaenr/scale-cd-jobs.git /root/scale-cd-jobs
         cd /root/scale-cd-jobs/build-scripts
         cd /root/svt/openshift_tooling/pbench
         if [[ $CONTAINERIZED == "true" ]]; then
@@ -42,7 +42,7 @@
         rm -rf /tmp/jenkins_prometheus/
         mkdir -p /tmp/jenkins_prometheus/
         cd /tmp/jenkins_prometheus/
-        git clone https://github.com/openshift/svt.git
+        git clone --depth=1 https://github.com/openshift/svt.git
         cd svt/openshift_scalability/ci/scripts/prometheus/
         chmod +x 'prometheus-loader.sh'
         ./prometheus-loader.sh ${REFRESH_INTERVAL} ${CONCURRENCY} ${GRAPH_PERIOD} ${DURATION} ${ENABLE_PBENCH} '${PBENCH_COPY_RESULTS}' '${PBENCH_USER_BENCHMARK}' ${TEST_NAME}

--- a/jjb/dynamic/cluster-density.yml
+++ b/jjb/dynamic/cluster-density.yml
@@ -6,7 +6,7 @@
         set -x
 
         # get perf keys to access orchestration host and set ssh session options
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         export OPTIONS="-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=1200"

--- a/jjb/dynamic/index.yml
+++ b/jjb/dynamic/index.yml
@@ -6,7 +6,7 @@
         set -eo pipefail
 
         # get perf keys to access orchestration host and set ssh session options
-        git clone https://${SSHKEY_TOKEN}@${SSHKEY_REPO}
+        git clone --depth=1 https://${SSHKEY_TOKEN}@${SSHKEY_REPO}
         if [ -f ${WORKSPACE}/${SSHKEY_REPOPATH_PUB} ] && [ -f ${WORKSPACE}/${SSHKEY_REPOPATH_PRIV} ]
         then
         export PUBLIC_KEY=${WORKSPACE}/${SSHKEY_REPOPATH_PUB}

--- a/jjb/dynamic/kubelet-density-light.yml
+++ b/jjb/dynamic/kubelet-density-light.yml
@@ -6,7 +6,7 @@
         set -x
 
         # get perf keys to access orchestration host and set ssh session options
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         export OPTIONS="-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=1200"

--- a/jjb/dynamic/kubelet-density.yml
+++ b/jjb/dynamic/kubelet-density.yml
@@ -6,7 +6,7 @@
         set -x
 
         # get perf keys to access orchestration host and set ssh session options
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         export OPTIONS="-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=1200"

--- a/jjb/dynamic/ns_per_cluster.yml
+++ b/jjb/dynamic/ns_per_cluster.yml
@@ -6,7 +6,7 @@
         set -e
 
         if [[ ! -d "${WORKSPACE}/perf-dept" ]]; then
-        git clone https://${GITHUB_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${GITHUB_TOKEN}@github.com/redhat-performance/perf-dept.git
         fi
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         chmod 600 ${PRIVATE_KEY}
@@ -22,7 +22,7 @@
         if [[ -d "/root/scale-cd-jobs" ]]; then
         rm -rf /root/scale-cd-jobs
         fi
-        git clone https://github.com/chaitanyaenr/scale-cd-jobs.git /root/scale-cd-jobs
+        git clone --depth=1 https://github.com/chaitanyaenr/scale-cd-jobs.git /root/scale-cd-jobs
         cd /root/scale-cd-jobs/build-scripts
         ./cluster_limits_ns.sh.python $SETUP_PBENCH $CONTAINERIZED $CLEAR_RESULTS $MOVE_RESULTS $TOOLING_INVENTORY $FIRST_RUN_PROJECTS $SECOND_RUN_PROJECTS $THIRD_RUN_PROJECTS $MODE
         exit
@@ -33,7 +33,7 @@
         if [[ -d "/root/scale-cd-jobs" ]]; then
         rm -rf /root/scale-cd-jobs
         fi
-        git clone https://github.com/chaitanyaenr/scale-cd-jobs.git /root/scale-cd-jobs
+        git clone --depth=1 https://github.com/chaitanyaenr/scale-cd-jobs.git /root/scale-cd-jobs
         cd /root/scale-cd-jobs/build-scripts
         if [[ $CONTAINERIZED == "true" ]]; then
         ./controller.sh

--- a/jjb/dynamic/scale-ci_ScaleUp_OpenShift.yml
+++ b/jjb/dynamic/scale-ci_ScaleUp_OpenShift.yml
@@ -10,7 +10,7 @@
         set -eux
 
         # Clone the repository that has the performance department's credentials.
-        git clone https://${GITHUB_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${GITHUB_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         chmod 600 ${PRIVATE_KEY}

--- a/jjb/dynamic/scale-ci_baseline.yml
+++ b/jjb/dynamic/scale-ci_baseline.yml
@@ -6,7 +6,7 @@
         set -eo pipefail
 
         # get perf keys to access orchestration host and set ssh session options
-        git clone https://${SSHKEY_TOKEN}@${SSHKEY_REPO}
+        git clone --depth=1 https://${SSHKEY_TOKEN}@${SSHKEY_REPO}
         if [ -f ${WORKSPACE}/${SSHKEY_REPOPATH_PUB} ] && [ -f ${WORKSPACE}/${SSHKEY_REPOPATH_PRIV} ]
         then
                 export PUBLIC_KEY=${WORKSPACE}/${SSHKEY_REPOPATH_PUB}

--- a/jjb/dynamic/scale-ci_build_tracker.yml
+++ b/jjb/dynamic/scale-ci_build_tracker.yml
@@ -7,7 +7,7 @@
 
         # enable logging
         set -x
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         export PBENCH_SSH_PUBLIC_KEY_FILE=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub

--- a/jjb/dynamic/scale-ci_conformance.yml
+++ b/jjb/dynamic/scale-ci_conformance.yml
@@ -7,7 +7,7 @@
         set -eux
 
         # get perf keys to access orchestration host and set ssh session options
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         export OPTIONS="-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=1200"

--- a/jjb/dynamic/scale-ci_deployments_per_ns.yml
+++ b/jjb/dynamic/scale-ci_deployments_per_ns.yml
@@ -7,7 +7,7 @@
         set -eux
 
         # get perf keys to access orchestration host and set ssh session options
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         export OPTIONS="-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=1200"

--- a/jjb/dynamic/scale-ci_http.yml
+++ b/jjb/dynamic/scale-ci_http.yml
@@ -7,7 +7,7 @@
         set -eux
 
         # get perf keys to access orchestration host and set ssh session options
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         export OPTIONS="-o StrictHostKeyChecking=no -o ServerAliveInterval=1 -o ConnectionAttempts=100"

--- a/jjb/dynamic/scale-ci_install_aws.yml
+++ b/jjb/dynamic/scale-ci_install_aws.yml
@@ -6,7 +6,7 @@
         set -o pipefail
         set -eux
 
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         chmod 600 ${PRIVATE_KEY}

--- a/jjb/dynamic/scale-ci_install_azure.yml
+++ b/jjb/dynamic/scale-ci_install_azure.yml
@@ -6,7 +6,7 @@
         set -o pipefail
         set -eux
 
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         chmod 600 ${PRIVATE_KEY}

--- a/jjb/dynamic/scale-ci_install_gcp.yml
+++ b/jjb/dynamic/scale-ci_install_gcp.yml
@@ -6,7 +6,7 @@
         set -o pipefail
         set -ex
 
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         chmod 600 ${PRIVATE_KEY}

--- a/jjb/dynamic/scale-ci_install_osp.yml
+++ b/jjb/dynamic/scale-ci_install_osp.yml
@@ -6,7 +6,7 @@
         set -o pipefail
         set -eux
 
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         chmod 600 ${PRIVATE_KEY}
@@ -31,7 +31,7 @@
         time ansible-playbook -i inventory -vvv delete_single_ocp.yml | tee $(date +"%Y%m%d-%H%M%S")-jetpack-delete-ocp.timing
         time ansible-playbook -i inventory -vvv ocp_on_osp.yml | tee $(date +"%Y%m%d-%H%M%S")-jetpack-install-ocp.timing
         fi
-        git clone https://github.com/cloud-bulldozer/scale-ci-deploy.git
+        git clone --depth=1 https://github.com/cloud-bulldozer/scale-ci-deploy.git
         cd scale-ci-deploy
         # disable openshift install as we already installed via jetpack
         export OPENSHIFT_INSTALL=false

--- a/jjb/dynamic/scale-ci_kraken.yml
+++ b/jjb/dynamic/scale-ci_kraken.yml
@@ -5,7 +5,7 @@
     - shell: |+
         set -euxo pipefail
 
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         chmod 600 ${PRIVATE_KEY}

--- a/jjb/dynamic/scale-ci_namespaces_per_cluster.yml
+++ b/jjb/dynamic/scale-ci_namespaces_per_cluster.yml
@@ -7,7 +7,7 @@
         set -eux
 
         # get perf keys to access orchestration host and set ssh session options
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         export OPTIONS="-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=1200"

--- a/jjb/dynamic/scale-ci_scale.yml
+++ b/jjb/dynamic/scale-ci_scale.yml
@@ -7,7 +7,7 @@
         set -ex
 
         # get perf keys to access orchestration host and set ssh session options
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         export OPTIONS="-o StrictHostKeyChecking=no -o ServerAliveInterval=1 -o ConnectionAttempts=100"

--- a/jjb/dynamic/scale-ci_services_per_namespace.yml
+++ b/jjb/dynamic/scale-ci_services_per_namespace.yml
@@ -7,7 +7,7 @@
         set -eux
 
         # get perf keys to access orchestration host and set ssh session options
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         export OPTIONS="-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=1200"

--- a/jjb/dynamic/scale-ci_tooling.yml
+++ b/jjb/dynamic/scale-ci_tooling.yml
@@ -8,7 +8,7 @@
 
 
         # get perf keys to access orchestration host and set ssh session options
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         export OPTIONS="-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=1200"

--- a/jjb/dynamic/uperf.yml
+++ b/jjb/dynamic/uperf.yml
@@ -8,7 +8,7 @@
         echo "Run ID is $RUN_ID"
 
         # get perf keys to access orchestration host and set ssh session options
-        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        git clone --depth=1 https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
         export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
         export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
         export OPTIONS="-o StrictHostKeyChecking=no -o ServerAliveInterval=1 -o ConnectionAttempts=100"

--- a/scale-ci-watcher.sh
+++ b/scale-ci-watcher.sh
@@ -91,7 +91,7 @@ function update_scale_ci_jobs() {
 	echo "                 Running scale-ci-watcher                         "
 	echo "------------------------------------------------------------------"
 	if [[ ! -d "$SCALE_CI_WATCHER_REPO_PATH" ]]; then
-        	git clone $SCALE_CI_WATCHER_REPO $SCALE_CI_WATCHER_REPO_PATH
+        	git clone --depth=1 $SCALE_CI_WATCHER_REPO $SCALE_CI_WATCHER_REPO_PATH
 		pushd $SCALE_CI_WATCHER_REPO_PATH
 		git checkout $SCALE_CI_WATCHER_REPO_BRANCH
 		popd


### PR DESCRIPTION
We're cloning big repositories such as perf-dept, using this flag will help to save some time.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>