### PR TITLE
add plugin for OpenID authentication on auth.redhat.com

### DIFF
--- a/containers/plugins.txt
+++ b/containers/plugins.txt
@@ -117,3 +117,4 @@ okhttp-api:3.14.9
 ansicolor:0.7.3
 metrics:4.0.2.6
 validating-string-parameter:2.8
+oic-auth:1.8


### PR DESCRIPTION
Plugin required to integrate authentication with auth.redhat.com

Integration process explained on https://docs.google.com/document/d/1wG4QmkcZ6rNIqC_Qt2YyKipLQUBbyX5wE3u1B9Yr7xU/edit#heading=h.8jepo7bs5bns