### PR TITLE
fix cluster-density invocation at stage-2

### DIFF
--- a/pipeline-scripts/workload.groovy
+++ b/pipeline-scripts/workload.groovy
@@ -50,7 +50,7 @@ stage (workload) {
 			}
 		}
 		else if (workload == "RIPSAW-CLUSTER-DENSITY") {
-			if (pipeline_stage != "1") {
+			if (pipeline_stage != "2") {
 				job_parameters = job_parameters.minus([$class: 'StringParameterValue', name: 'JOB_ITERATIONS', value: properties['JOB_ITERATIONS']])
 				if (pipeline_stage == "3") {
 					job_parameters.add([$class: 'StringParameterValue', name: 'JOB_ITERATIONS', value: properties['JOB_ITERATIONS_V2'] ])
@@ -58,7 +58,7 @@ stage (workload) {
 					job_parameters.add([$class: 'StringParameterValue', name: 'JOB_ITERATIONS', value: properties['JOB_ITERATIONS_V3'] ])
 				} else if (pipeline_stage == "5") {
 					job_parameters.add([$class: 'StringParameterValue', name: 'JOB_ITERATIONS', value: properties['JOB_ITERATIONS_V4'] ])
-				} else if (pipeline_stage == "5") {
+				} else if (pipeline_stage == "6") {
 					job_parameters.add([$class: 'StringParameterValue', name: 'JOB_ITERATIONS', value: properties['JOB_ITERATIONS_V5'] ])
 				}
 			}


### PR DESCRIPTION
1. CLUSTER-DENSITY starts at stage-2
so at stage-2 it will [scrape the params](https://github.com/cloud-bulldozer/scale-ci-pipeline/blob/743697f6b658f903e99309b534c557a66ce0f2a0/pipeline-scripts/workload.groovy#L32) from the properties file provided, no fuss here

2. now at stage-3 we want to have JOB_ITERATION=JOB_ITERATIONS_V2
for that we [remove the earlier set JOB_ITERATIONS var](https://github.com/cloud-bulldozer/scale-ci-pipeline/blob/743697f6b658f903e99309b534c557a66ce0f2a0/pipeline-scripts/workload.groovy#L54) and [reassign it to JOB_ITERATIONS_V2](https://github.com/cloud-bulldozer/scale-ci-pipeline/blob/743697f6b658f903e99309b534c557a66ce0f2a0/pipeline-scripts/workload.groovy#L56)

3. [the next stages](https://github.com/cloud-bulldozer/scale-ci-pipeline/blob/743697f6b658f903e99309b534c557a66ce0f2a0/pipeline-scripts/workload.groovy#L57-L62) follow the same suite as Step 2 above