### PR TITLE
Node density

### DIFF
--- a/jjb/dynamic/cluster-density.yml
+++ b/jjb/dynamic/cluster-density.yml
@@ -19,13 +19,11 @@
         export KUBECONFIG=${WORKSPACE}/kubeconfig
 
         # run tests
-        export TERM=screen-256color
         pushd workloads/kube-burner
         ./run_clusterdensity_test_fromgit.sh
     concurrent: true
     description: |
-      Cluster-density workload is used to measure control plane density for OpenShift. This test loads several objects across the cluster using cluster loader.
-      This job is managed by https://github.com/openshift-scale/scale-ci-pipeline
+      Cluster-density workload is used to measure control plane density for OpenShift. This test loads several objects across the cluster using kube-burner.
     disabled: false
     name: RIPSAW-CLUSTER-DENSITY
     node: scale-ci

--- a/jjb/dynamic/node-density-light.yml
+++ b/jjb/dynamic/node-density-light.yml
@@ -19,13 +19,11 @@
         export KUBECONFIG=${WORKSPACE}/kubeconfig
 
         # run tests
-        export TERM=screen-256color
         pushd workloads/kube-burner
-        ./run_kubeletdensity_test_fromgit.sh
+        ./run_nodedensity_test_fromgit.sh
     concurrent: true
     description: |
-      Cluster-density-light workload is used to measure control plane density for OpenShift. This test loads several objects across the cluster using cluster loader.
-      This job is managed by https://github.com/openshift-scale/scale-ci-pipeline
+      Creates a single namespace with a number of Deployments equal to job_iterations
     disabled: false
     name: RIPSAW-NODE-DENSITY-LIGHT
     node: scale-ci

--- a/jjb/dynamic/node-density.yml
+++ b/jjb/dynamic/node-density.yml
@@ -19,13 +19,12 @@
         export KUBECONFIG=${WORKSPACE}/kubeconfig
 
         # run tests
-        export TERM=screen-256color
         pushd workloads/kube-burner
-        ./run_kubeletdensity-heavy_test_fromgit.sh
+        ./run_nodedensity-heavy_test_fromgit.sh
     concurrent: true
     description: |
-      Cluster-density workload is used to measure control plane density for OpenShift. This test loads several objects across the cluster using cluster loader.
-      This job is managed by https://github.com/openshift-scale/scale-ci-pipeline
+      Creates a single namespace with a number of applications equals to job_iterations.
+      This application consists of two deployments (a postgresql database and a simple client that generates some CPU load) and a service that is used by the client to reach the database.
     disabled: false
     name: RIPSAW-NODE-DENSITY
     node: scale-ci


### PR DESCRIPTION
I forgot to update the script names from job templates, updating them.

Also removing `export TERM=screen-256color` which is no longer required (The scripts doesn't use tput to print bold characters anymore)