### PR TITLE
using different networktype for ocp-on-osp on different days of week

### DIFF
--- a/jjb/dynamic/scale-ci_install_osp.yml
+++ b/jjb/dynamic/scale-ci_install_osp.yml
@@ -22,16 +22,20 @@
         for (( iter=1; iter<=$JOB_ITERATIONS; iter++ ))
         do
         
-        # Get the day of week and set networkType as OpenshiftSDN on odd days and kuryr on even days.
-        DOW=$(date +%u)
-        rem=$(( $DOW % 2 ))
-        if [ $rem -eq 0 ]
+        # Get the day of week and set networkType as OpenshiftSDN on odd days and kuryr on even days in case no netork is defined manually.
+        if [ $OPENSHIFT_NETWORK_TYPE == "" ]
         then
-          echo "Using kuryr as Network Type"
-          export OPENSHIFT_NETWORK_TYPE=Kuryr
-        else
-          echo "Using OpenshiftSDN as Network Type"
-          export OPENSHIFT_NETWORK_TYPE=OpenshiftSDN
+            DOW=$(date +%u)
+            rem=$(( $DOW % 2 ))
+            if [ $rem -eq 0 ]
+            then
+                echo "Using kuryr as Network Type"
+                export OPENSHIFT_NETWORK_TYPE=kuryr
+            else
+                echo "Using OpenshiftSDN as Network Type"
+                export OPENSHIFT_NETWORK_TYPE=OpenshiftSDN
+            fi
+        fi
 
         if [ $INSTALL_OSP == true ]
         then

--- a/jjb/dynamic/scale-ci_install_osp.yml
+++ b/jjb/dynamic/scale-ci_install_osp.yml
@@ -21,6 +21,18 @@
         cp ci/ocp_install_vars.yml vars/shift_stack_vars.yaml
         for (( iter=1; iter<=$JOB_ITERATIONS; iter++ ))
         do
+        
+        # Get the day of week and set networkType as OpenshiftSDN on odd days and kuryr on even days.
+        DOW=$(date +%u)
+        rem=$(( $DOW % 2 ))
+        if [ $rem -eq 0 ]
+        then
+          echo "Using kuryr as Network Type"
+          export OPENSHIFT_NETWORK_TYPE=kuryr
+        else
+          echo "Using OpenshiftSDN as Network Type"
+          export OPENSHIFT_NETWORK_TYPE=OpenshiftSDN
+
         if [ $INSTALL_OSP == true ]
         then
         time ansible-playbook -vvv main.yml | tee $(date +"%Y%m%d-%H%M%S")-jetpack-install.timing

--- a/jjb/dynamic/scale-ci_install_osp.yml
+++ b/jjb/dynamic/scale-ci_install_osp.yml
@@ -28,7 +28,7 @@
         if [ $rem -eq 0 ]
         then
           echo "Using kuryr as Network Type"
-          export OPENSHIFT_NETWORK_TYPE=kuryr
+          export OPENSHIFT_NETWORK_TYPE=Kuryr
         else
           echo "Using OpenshiftSDN as Network Type"
           export OPENSHIFT_NETWORK_TYPE=OpenshiftSDN

--- a/jjb/dynamic/scale-ci_install_osp.yml
+++ b/jjb/dynamic/scale-ci_install_osp.yml
@@ -22,7 +22,7 @@
         for (( iter=1; iter<=$JOB_ITERATIONS; iter++ ))
         do
         
-        # Get the day of week and set networkType as OpenshiftSDN on odd days and kuryr on even days in case no netork is defined manually.
+        # Get the day of week and set networkType as OpenshiftSDN on odd days and kuryr on even days in case no network is defined manually.
         if [ $OPENSHIFT_NETWORK_TYPE == "" ]
         then
             DOW=$(date +%u)
@@ -30,7 +30,7 @@
             if [ $rem -eq 0 ]
             then
                 echo "Using kuryr as Network Type"
-                export OPENSHIFT_NETWORK_TYPE=kuryr
+                export OPENSHIFT_NETWORK_TYPE=Kuryr
             else
                 echo "Using OpenshiftSDN as Network Type"
                 export OPENSHIFT_NETWORK_TYPE=OpenshiftSDN


### PR DESCRIPTION
For openshift install on osp role.
Setting OPENSHIFT_NETWORK_TYPE=OpenshiftSDN for idd days of week
and OPENSHIFT_NETWORK_TYPE=kuryr for the even days of week

