### PR TITLE
Adds nightly job for testing perfscale managed services

### DIFF
--- a/containers/plugins.txt
+++ b/containers/plugins.txt
@@ -80,6 +80,7 @@ jsch:0.1.55.2
 config-file-provider:3.7.0
 publish-over:0.22
 parameterized-trigger:2.39
+parameterized-scheduler:0.9.2
 authentication-tokens:1.4
 docker-workflow:1.25
 jdk-tool:1.4

--- a/jjb/dynamic/nightly-perfscale-managed-services.yml
+++ b/jjb/dynamic/nightly-perfscale-managed-services.yml
@@ -1,0 +1,55 @@
+- job:
+    block-downstream: false
+    block-upstream: false
+    builders:
+      - shell: |+
+            #!/bin/bash
+
+            set +e
+            echo "Building image..."
+            podman build -f tests/Dockerfile --tag tox-test:latest .
+            echo "Running tests..."
+            podman run --rm -ti tox-test:latest
+            echo "Cleaning up temporary image..."
+            podman rmi -f tox-test:latest
+    concurrent: false
+    description: Nightly test run on perfscale-managed-services.
+    disabled: false
+    name: 'NIGHTLY-PERFSCALE-MANAGED-SERVICES'
+    parameters:
+    - label:
+        name: node_label
+        description: "Label of the node to build in"
+        matching-label: "success"
+        node-eligibility: "all"
+        default: "scale-ci"
+    - git-parameter:
+        name: branch
+        type: PT_BRANCH_TAG
+        sortMode: ASCENDING
+        defaultValue: origin/main
+        selectedValue: TOP
+        quickFilterEnabled: true
+    project-type: freestyle
+    publishers:
+      - workspace-cleanup
+    label: simple
+    scm:
+    - git:
+        branches:
+        - '**'
+        url: https://github.com/cloud-bulldozer/perfscale-managed-services.git
+        wipe-workspace: true
+        refspec: '+refs/heads/*:refs/remotes/remoteName/*'
+    triggers:
+    - timed:
+        cron: 'H 00 * * *'
+    - parameterized-timer:
+        cron: 'H 00 * * * % branch=origin/0.0.1' #Builds latest release
+    wrappers:
+      - timestamps
+      - workspace-cleanup:
+            dirmatch: false
+      - mask-passwords
+      - ansicolor:
+          colormap: xterm


### PR DESCRIPTION
Adds nightly job to test perfscale-managed-services.
Programs a trigger nightly for master and for the latest release.

Still need to come up with a way to build the latest release without updating this job each time.

Signed-off-by: Vicente Zepeda Mas <vzepedam@redhat.com>