### PR TITLE
Removed hardcoded reference to AWS_PROFILE

### DIFF
--- a/jjb/dynamic/scale-ci-ms-osde2e.yml
+++ b/jjb/dynamic/scale-ci-ms-osde2e.yml
@@ -94,7 +94,6 @@
             [ ! -z ${LOG_FILE} ] && WRAPPER_OPTIONS+=" --log-file ${REMOTE_WORKSPACE}/run-${RUN_FOLDER}/${LOG_FILE}"
 
             # Wrapper execution
-            export AWS_PROFILE='openshift-perfscale'
             echo "INFO: Running python3 ${REMOTE_WORKSPACE}/run-${RUN_FOLDER}/perfscale-managed-services/osde2e/osde2e-wrapper.py \${WRAPPER_OPTIONS}"
             python3 ${REMOTE_WORKSPACE}/run-${RUN_FOLDER}/perfscale-managed-services/osde2e/osde2e-wrapper.py \${WRAPPER_OPTIONS}
           ENDSSH


### PR DESCRIPTION
Typo injected on the tests, the user is responsible to create this var on the jumhost if there is more than one aws credentials availables