### PR TITLE
move cleanup process to a post-task

### DIFF
--- a/jjb/dynamic/scale-ci-ms-osde2e.yml
+++ b/jjb/dynamic/scale-ci-ms-osde2e.yml
@@ -70,8 +70,6 @@
 
             [ ! -z ${OSDE2E_SKIP_HEALTH_CHECK} ] && [ ${OSDE2E_SKIP_HEALTH_CHECK} == "true" ] && WRAPPER_OPTIONS+=" --skip-health-check"
 
-            [ ! -z ${CLEANUP_CLUSTERS} ] && [ ${CLEANUP_CLUSTERS} == "false" ] && WRAPPER_OPTIONS+=" --cleanup-clusters False"
-
             if [ ! -z ${ELASTICSEARCH_URL} ] ; then
               WRAPPER_OPTIONS+=" --es-url ${ELASTICSEARCH_URL}"
               [ ! -z ${ELASTICSEARCH_INDEX} ] && WRAPPER_OPTIONS+=" --es-index ${ELASTICSEARCH_INDEX}"
@@ -191,10 +189,6 @@
           name: NUMBER_OF_CLUSTERS
           regex: '[0-9]*'
           msg: "Must be a number"
-      - bool:
-          default: true
-          description: "Mapped to <b>--cleanup-clusters</b>, cleanup any non-error state clusters upon test completion"
-          name: CLEANUP_CLUSTERS
       - validating-string:
           default: ''
           description: "Mapped to <b>--batch-size</b>, number of cluster to install on parallel"
@@ -233,11 +227,56 @@
             - WARNING
             - DEBUG
       - bool:
+          default: false
+          description: "Delete all clusters at the end of the job"
+          name: CLEANUP_CLUSTERS
+      - bool:
           default: true
           description: "Compress log files created before being downloaded in the Jenkins host as artifacts"
           name: COMPRESS_LOGS
     project-type: freestyle
     publishers:
+      - postbuildscript:
+          builders:
+            - role: BOTH
+              build-on:
+                - SUCCESS
+                - FAILURE
+                - UNSTABLE
+                - NOT_BUILT
+                - ABORTED
+              build-steps:
+                - conditional-step:
+                    condition-kind: boolean-expression
+                    condition-expression: ${CLEANUP_CLUSTERS}
+                    steps:
+                      - shell: |+
+                          #!/bin/bash
+                          set -e
+                          echo "INFO: Getting perf-dept keys"
+                          export RUN_FOLDER=${BUILD_TIMESTAMP}
+                          export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
+                          export OPTIONS="-o StrictHostKeyChecking=no -o ServerAliveInterval=1 -o ConnectionAttempts=100"
+                          [[ "${USE_PROXY}" == "true" ]] && OPTIONS+=" -o ProxyCommand=\"ssh -i ${PRIVATE_KEY} -W %h:%p ${PROXY_USER}@${PROXY_HOST}\""
+                          # Delete clusters after tests are executed
+                          echo "INFO: Delete clusters"
+                          ssh ${OPTIONS} -i ${PRIVATE_KEY} ${SSH_USER}@${JUMP_HOST} 'bash -s' <<ENDSSH
+                            set -e
+                            # Parameter checks
+                            WRAPPER_OPTIONS="--only-delete-clusters --path ${REMOTE_WORKSPACE}/run-${RUN_FOLDER}"
+                            if [ -z ${CONFIG_FILE_LOCATION} ] || [ ! -f ${CONFIG_FILE_LOCATION} ] ; then
+                              echo "ERROR: Config file ${CONFIG_FILE_LOCATION} not found, exiting..."
+                              exit 1
+                            else
+                              WRAPPER_OPTIONS+=" --account-config ${CONFIG_FILE_LOCATION}"
+                            fi
+                            [ ! -z ${OSDE2E_COMMAND} ] && WRAPPER_OPTIONS+=" --command ${OSDE2E_COMMAND}"
+                            [ ! -z ${LOG_LEVEL} ] && WRAPPER_OPTIONS+=" --log-level ${LOG_LEVEL}"
+                            [ ! -z ${LOG_FILE} ] && WRAPPER_OPTIONS+=" --log-file ${REMOTE_WORKSPACE}/run-${RUN_FOLDER}/${LOG_FILE}"
+                            # Wrapper execution
+                            echo "INFO: Running python3 ${REMOTE_WORKSPACE}/run-${RUN_FOLDER}/perfscale-managed-services/osde2e/osde2e-wrapper.py \${WRAPPER_OPTIONS}"
+                            python3 ${REMOTE_WORKSPACE}/run-${RUN_FOLDER}/perfscale-managed-services/osde2e/osde2e-wrapper.py \${WRAPPER_OPTIONS}
+                          ENDSSH
       - archive:
           artifacts: 'artifacts/**/*'
           excludes: 'artifacts/perfscale-managed-services/**/*,artifacts/osde2e/**/*,artifacts/account_config.yaml,artifacts/**/cluster_account.yaml'

--- a/jjb/dynamic/scale-ci-ms-rosa.yml
+++ b/jjb/dynamic/scale-ci-ms-rosa.yml
@@ -65,11 +65,11 @@
 
             [ ! -z ${ROSA_ADDONS} ] && WRAPPER_OPTIONS+=" --rosa-addons ${ROSA_ADDONS}"
 
+            [ ! -z ${ROSA_INIT} ] && [ ${ROSA_INIT} == true ] && WRAPPER_OPTIONS+=" --rosa-init"
+
             [ ! -z ${ROSA_CLI} ] && WRAPPER_OPTIONS+=" --rosa-cli ${ROSA_CLI}"
 
             [ ! -z ${AWS_PROFILE} ] && WRAPPER_OPTIONS+=" --aws-profile ${AWS_PROFILE}"
-
-            [ ! -z ${CLEANUP_CLUSTERS} ] && [ ${CLEANUP_CLUSTERS} == "false" ] && WRAPPER_OPTIONS+=" --cleanup-clusters False"
 
             if [ ! -z ${ELASTICSEARCH_URL} ] ; then
               WRAPPER_OPTIONS+=" --es-url ${ELASTICSEARCH_URL}"
@@ -202,10 +202,6 @@
           name: NUMBER_OF_CLUSTERS
           regex: '[0-9]*'
           msg: "Must be a number"
-      - bool:
-          default: true
-          description: "Mapped to <b>--cleanup-clusters</b>, cleanup any non-error state clusters upon test completion"
-          name: CLEANUP_CLUSTERS
       - validating-string:
           default: ''
           description: "Mapped to <b>--batch-size</b>, number of cluster to install on parallel"
@@ -244,11 +240,56 @@
             - WARNING
             - DEBUG
       - bool:
+          default: false
+          description: "Delete all clusters at the end of the job"
+          name: CLEANUP_CLUSTERS
+      - bool:
           default: true
           description: "Compress log files created before being downloaded in the Jenkins host as artifacts"
           name: COMPRESS_LOGS
     project-type: freestyle
     publishers:
+      - postbuildscript:
+          builders:
+            - role: BOTH
+              build-on:
+                - SUCCESS
+                - FAILURE
+                - UNSTABLE
+                - NOT_BUILT
+                - ABORTED
+              build-steps:
+                - conditional-step:
+                    condition-kind: boolean-expression
+                    condition-expression: ${CLEANUP_CLUSTERS}
+                    steps:
+                      - shell: |+
+                          #!/bin/bash
+                          set -e
+                          echo "INFO: Getting perf-dept keys"
+                          export RUN_FOLDER=${BUILD_TIMESTAMP}
+                          export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
+                          export OPTIONS="-o StrictHostKeyChecking=no -o ServerAliveInterval=1 -o ConnectionAttempts=100"
+                          [[ "${USE_PROXY}" == "true" ]] && OPTIONS+=" -o ProxyCommand=\"ssh -i ${PRIVATE_KEY} -W %h:%p ${PROXY_USER}@${PROXY_HOST}\""
+                          # Delete clusters after tests are executed
+                          echo "INFO: Delete clusters"
+                          ssh ${OPTIONS} -i ${PRIVATE_KEY} ${SSH_USER}@${JUMP_HOST} 'bash -s' <<ENDSSH
+                            set -e
+                            # Parameter checks
+                            WRAPPER_OPTIONS="--only-delete-clusters --path ${REMOTE_WORKSPACE}/run-${RUN_FOLDER}"
+                            if [ -z ${ROSA_TOKEN} ] ; then
+                              echo "ERROR: Rosa token is required but it is not defined, exiting..."
+                              exit 1
+                            else
+                              WRAPPER_OPTIONS+=" --rosa-token ${ROSA_TOKEN}"
+                            fi
+                            [ ! -z ${ROSA_CLI} ] && WRAPPER_OPTIONS+=" --rosa-cli ${ROSA_CLI}"
+                            [ ! -z ${LOG_LEVEL} ] && WRAPPER_OPTIONS+=" --log-level ${LOG_LEVEL}"
+                            [ ! -z ${LOG_FILE} ] && WRAPPER_OPTIONS+=" --log-file ${REMOTE_WORKSPACE}/run-${RUN_FOLDER}/${LOG_FILE}"
+                            # Wrapper execution
+                            echo "INFO: Running python3 ${REMOTE_WORKSPACE}/run-${RUN_FOLDER}/perfscale-managed-services/rosa/rosa-wrapper.py \${WRAPPER_OPTIONS}"
+                            python3 ${REMOTE_WORKSPACE}/run-${RUN_FOLDER}/perfscale-managed-services/rosa/rosa-wrapper.py \${WRAPPER_OPTIONS}
+                          ENDSSH
       - archive:
           artifacts: 'artifacts/**/*'
           excludes: 'artifacts/perfscale-managed-services/**/*,artifacts/rosa'


### PR DESCRIPTION
Move cleanup process to a post-task on osde2e and rosa jobs.

After this merge, clusters will be preserved by default. Cleanup process will be only executed if CLEANUP_CLUSTERS var is true
